### PR TITLE
refactor(netlink): provide blanket impl for box<T> in link

### DIFF
--- a/crates/netlink/examples/addr.rs
+++ b/crates/netlink/examples/addr.rs
@@ -21,22 +21,20 @@ fn main() {
         ..Default::default()
     };
 
-    netlink.addr_handle(AddrCmd::Add, &*link, &addr).unwrap();
+    netlink.addr_handle(AddrCmd::Add, &link, &addr).unwrap();
 
-    let result = netlink.addr_show(&*link).unwrap();
+    let result = netlink.addr_show(&link).unwrap();
     println!("{:?}", result);
 
     addr.ip = "127.0.0.3/24".parse().unwrap();
 
-    netlink
-        .addr_handle(AddrCmd::Replace, &*link, &addr)
-        .unwrap();
+    netlink.addr_handle(AddrCmd::Replace, &link, &addr).unwrap();
 
-    let result = netlink.addr_show(&*link).unwrap();
+    let result = netlink.addr_show(&link).unwrap();
     println!("{:?}", result);
 
-    netlink.addr_handle(AddrCmd::Del, &*link, &addr).unwrap();
+    netlink.addr_handle(AddrCmd::Del, &link, &addr).unwrap();
 
-    let result = netlink.addr_show(&*link).unwrap();
+    let result = netlink.addr_show(&link).unwrap();
     println!("{:?}", result);
 }

--- a/crates/netlink/examples/link.rs
+++ b/crates/netlink/examples/link.rs
@@ -22,12 +22,12 @@ fn link_add_modify_del() -> Result<()> {
     println!("link name: {}", link.attrs().name);
 
     link.attrs_mut().name = "bar".to_string();
-    netlink.link_modify(&*link)?;
+    netlink.link_modify(&link)?;
 
     let link = netlink.link_get(link.attrs())?;
     println!("link name: {}", link.attrs().name);
 
-    netlink.link_del(&*link)?;
+    netlink.link_del(&link)?;
 
     Ok(())
 }

--- a/crates/netlink/src/link.rs
+++ b/crates/netlink/src/link.rs
@@ -38,6 +38,24 @@ pub trait Link {
     fn kind(&self) -> &Kind;
 }
 
+impl<T: Link + ?Sized> Link for Box<T> {
+    fn link_type(&self) -> String {
+        (**self).link_type()
+    }
+
+    fn attrs(&self) -> &LinkAttrs {
+        (**self).attrs()
+    }
+
+    fn attrs_mut(&mut self) -> &mut LinkAttrs {
+        (**self).attrs_mut()
+    }
+
+    fn kind(&self) -> &Kind {
+        (**self).kind()
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct LinkAttrs {
     pub link_type: String,

--- a/crates/netlink/src/message.rs
+++ b/crates/netlink/src/message.rs
@@ -144,10 +144,7 @@ impl NetlinkRouteAttr {
         }
     }
 
-    pub fn add_child_from_attr<T>(&mut self, attr: Box<T>)
-    where
-        T: NetlinkRequestData + 'static,
-    {
+    pub fn add_child_from_attr(&mut self, attr: Box<(impl NetlinkRequestData + 'static)>) {
         self.rt_attr.rta_len += attr.len() as u16;
 
         match &mut self.children {


### PR DESCRIPTION
Provide a blanket implementation for `Box<T> where T: Link + ?Sized` in the Link trait.